### PR TITLE
Add note for debugServer setting in launch.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ As an example, for Powershell on Windows it could look like this:
 PS C:\Users\felix\github\vscode-php-debug> code .\testproject\ --extensionDevelopmentPath=$pwd
 ```
 
-VS Code will open an "Extension Development Host" with the debug adapter running.
+VS Code will open an "Extension Development Host" with the debug adapter running. Open `.vscode/launch.json` and
+uncomment the `debugServer` configuration line. Hit `F5` to start a debugging session. 
 Now, you can debug the testproject like specified above and set breakpoints inside your first VS Code instance to step through the adapter code.
 
 [![Gitter](https://badges.gitter.im/felixfbecker/vscode-php-debug.svg)](https://gitter.im/felixfbecker/vscode-php-debug?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)

--- a/testproject/.vscode/launch.json
+++ b/testproject/.vscode/launch.json
@@ -1,5 +1,7 @@
 {
 	"version": "0.2.0",
+
+	// "debugServer": 4711, // Uncomment for debugging the adapter
 	"configurations": [
 		{
 			"name": "Listen for XDebug",

--- a/testproject/.vscode/launch.json
+++ b/testproject/.vscode/launch.json
@@ -1,6 +1,5 @@
 {
 	"version": "0.2.0",
-
 	// "debugServer": 4711, // Uncomment for debugging the adapter
 	"configurations": [
 		{


### PR DESCRIPTION
without the debugServer switch there was no obvious way for me to debug the adapter.