### PR TITLE
Add sourcemap feature for remote host debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ What is not supported?
  - Breaking on _caught_ exceptions, this is not supported by XDebug and the setting is ignored
  - Attach requests, there is no such thing because the lifespan of PHP scripts is short
 
+Remote Host Debugging
+---------------------
+If you want to debug a running application on a remote host, you have to set the `localSourceRoot` and `serverSourceRoot` settings in your launch.json.
+Example:
+```json
+"serverSourceRoot": "/var/www/myproject",
+"localSourceRoot": "./src"
+```
+`localSourceRoot` is resolved relative to the project root (the currently opened folder in VS Code).
+Both paths are normalized, so you can use slashes or backslashes no matter of the OS you're running.
+If no `localSourceRoot` is specified, the project root is assumed.
+
 FAQ
 ---
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "iconv-lite": "^0.4.13",
     "moment": "^2.10.6",
+    "url-relative": "^1.0.0",
     "vscode-debugadapter": "^1.0.3",
     "vscode-debugprotocol": "^1.0.1",
     "xmldom": "^0.1.19"
@@ -75,6 +76,14 @@
                 "type": "number",
                 "description": "Port on which to listen for XDebug",
                 "default": 9000
+              },
+              "serverSourceRoot": {
+                "type": "string",
+                "description": "The source root when debugging a remote host"
+              },
+              "localSourceRoot": {
+                "type": "string",
+                "description": "The source root on this machine that is the equivalent to the serverSourceRoot on the server. May be relative to the project root."
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -1,85 +1,93 @@
 {
-    "name": "php-debug",
-    "displayName": "PHP Debug",
-    "version": "1.0.1",
-    "publisher": "felixfbecker",
-    "description": "Debug support for PHP with XDebug",
-    "keywords": ["php", "debug", "xdebug"],
-    "author": {
-        "name": "Felix Becker",
-        "email": "felix.b@outlook.com"
-    },
-    "engines": {
-        "vscode": "^0.10.6",
-        "node": ">=4.0.0"
-    },
-    "icon": "images/logo.svg",
-    "galleryBanner": {
-        "color": "#6682BA",
-        "theme": "dark"
-    },
-    "categories": ["Debuggers"],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/felixfbecker/vscode-php-debug.git"
-    },
-    "bugs": {
-        "url": "https://github.com/felixfbecker/vscode-php-debug/issues"
-    },
-    "dependencies": {
-        "iconv-lite": "^0.4.13",
-        "moment": "^2.10.6",
-        "vscode-debugadapter": "^1.0.3",
-        "vscode-debugprotocol": "^1.0.1",
-        "xmldom": "^0.1.19"
-    },
-    "devDependencies": {
-        "typescript": "^1.6.2",
-        "mocha": "*"
-    },
-    "scripts": {
-        "compile": "tsc -p ./src",
-        "watch": "tsc -w -p ./src",
-        "publish": "vsce publish",
-        "vscode:prepublish": "npm run compile",
-        "test": "mocha out/tests"
-    },
-    "contributes": {
-        "debuggers": [
-            {
-                "type": "php",
-                "label": "PHP",
-                "enableBreakpointsFor": {
-                    "languageIds": ["php"]
-                },
-                "program": "./out/phpDebug.js",
-                "runtime": "node",
-                "configurationAttributes": {
-                    "launch": {
-                        "required": [],
-                        "properties": {
-                            "stopOnEntry": {
-                                "type": "boolean",
-                                "description": "Automatically stop after launch.",
-                                "default": true
-                            },
-                            "port": {
-                                "type": "number",
-                                "description": "Port on which to listen for XDebug",
-                                "default": 9000
-                            }
-                        }
-                    }
-                },
-                "initialConfigurations": [
-                    {
-                        "name": "Listen for XDebug",
-                        "type": "php",
-                        "request": "launch",
-                        "port": 9000
-                    }
-                ]
+  "name": "php-debug",
+  "displayName": "PHP Debug",
+  "version": "1.0.1",
+  "publisher": "felixfbecker",
+  "description": "Debug support for PHP with XDebug",
+  "keywords": [
+    "php",
+    "debug",
+    "xdebug"
+  ],
+  "author": {
+    "name": "Felix Becker",
+    "email": "felix.b@outlook.com"
+  },
+  "engines": {
+    "vscode": "^0.10.6",
+    "node": ">=4.0.0"
+  },
+  "icon": "images/logo.svg",
+  "galleryBanner": {
+    "color": "#6682BA",
+    "theme": "dark"
+  },
+  "categories": [
+    "Debuggers"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/felixfbecker/vscode-php-debug.git"
+  },
+  "bugs": {
+    "url": "https://github.com/felixfbecker/vscode-php-debug/issues"
+  },
+  "dependencies": {
+    "iconv-lite": "^0.4.13",
+    "moment": "^2.10.6",
+    "vscode-debugadapter": "^1.0.3",
+    "vscode-debugprotocol": "^1.0.1",
+    "xmldom": "^0.1.19"
+  },
+  "devDependencies": {
+    "typescript": "^1.6.2",
+    "mocha": "*"
+  },
+  "scripts": {
+    "compile": "tsc -p ./src",
+    "watch": "tsc -w -p ./src",
+    "publish": "vsce publish",
+    "vscode:prepublish": "npm run compile",
+    "test": "mocha out/tests"
+  },
+  "contributes": {
+    "debuggers": [
+      {
+        "type": "php",
+        "label": "PHP",
+        "enableBreakpointsFor": {
+          "languageIds": [
+            "php"
+          ]
+        },
+        "program": "./out/phpDebug.js",
+        "runtime": "node",
+        "configurationAttributes": {
+          "launch": {
+            "required": [],
+            "properties": {
+              "stopOnEntry": {
+                "type": "boolean",
+                "description": "Automatically stop after launch.",
+                "default": true
+              },
+              "port": {
+                "type": "number",
+                "description": "Port on which to listen for XDebug",
+                "default": 9000
+              }
             }
+          }
+        },
+        "initialConfigurations": [
+          {
+            "name": "Listen for XDebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9000
+          }
         ]
-    }
+      }
+    ]
+  }
 }

--- a/src/typings/url-relative/url-relative.d.ts
+++ b/src/typings/url-relative/url-relative.d.ts
@@ -1,0 +1,4 @@
+declare module 'url-relative' {
+    function relative(from: string, to: string): string;
+    export = relative;
+}


### PR DESCRIPTION
@gianugo I switched from regexps to using url and path resolve and relative functions, which should be more robust. If you could confirm again that everything works I will merge this.