### PR TITLE
Mapping local absolute file paths

### DIFF
--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -198,7 +198,7 @@ class PhpDebugSession extends vscode.DebugSession {
     /** converts a server-side XDebug file URI to a local path for VS Code with respect to source root settings */
     protected convertDebuggerPathToClient(fileUri: string): string {
         // convert the file URI to a path. Don't remove starting slash on unix platforms.
-        let n:number = (process.platform === 'win32') ? 1 : 0;
+        let n: number = (process.platform === 'win32') ? 1 : 0;
         const serverPath = decodeURI(url.parse(fileUri).pathname.substr(n));
         let localPath: string;
         if (this._args.serverSourceRoot && this._args.localSourceRoot) {

--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -197,8 +197,9 @@ class PhpDebugSession extends vscode.DebugSession {
 
     /** converts a server-side XDebug file URI to a local path for VS Code with respect to source root settings */
     protected convertDebuggerPathToClient(fileUri: string): string {
-        // convert the file URI to a path
-        const serverPath = decodeURI(url.parse(fileUri).pathname.substr(1));
+        // convert the file URI to a path. Don't remove starting slash on unix platforms.
+        let n:number = (process.platform === 'win32') ? 1 : 0;
+        const serverPath = decodeURI(url.parse(fileUri).pathname.substr(n));
         let localPath: string;
         if (this._args.serverSourceRoot && this._args.localSourceRoot) {
             // get the part of the path that is relative to the source root
@@ -217,7 +218,6 @@ class PhpDebugSession extends vscode.DebugSession {
         if (localFileUri[0] !== '/') {
             localFileUri = '/' + localFileUri;
         }
-        localFileUri = encodeURI('file://' + localFileUri);
         let serverFileUri: string;
         if (this._args.serverSourceRoot && this._args.localSourceRoot) {
             // get the part of the path that is relative to the source root
@@ -227,6 +227,7 @@ class PhpDebugSession extends vscode.DebugSession {
         } else {
             serverFileUri = localFileUri;
         }
+        serverFileUri = encodeURI('file://' + serverFileUri);
         return serverFileUri;
     }
 


### PR DESCRIPTION
Take 2.

I was able to roll back most of my changes including the `string.replace()` and end up with two minor tweaks that made the proper difference.
'
1. The platform switch on the `substring` performed on the URI returned from XDebug
2. Making sure `serverFileUri` gets "file://" prepended. 

With these in place the relative path resolving works in all of my setups.