### PR TITLE
dump error messages to the debug window

### DIFF
--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -643,10 +643,10 @@ class PhpDebugSession extends vscode.DebugSession {
                     new vscode.Variable('type', status.exception.name),
                     new vscode.Variable('message', '"' + status.exception.message + '"')
                 ];
-                
+
                 // drop the messages into the full debug pane where it can be read in full.
                 this.sendEvent(new vscode.OutputEvent(status.exception.message + '\n'));
-                
+
                 if (status.exception.code !== undefined) {
                     variables.push(new vscode.Variable('code', status.exception.code + ''));
                 }

--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -645,7 +645,7 @@ class PhpDebugSession extends vscode.DebugSession {
                 ];
                 
                 // drop the messages into the full debug pane where it can be read in full.
-                this.sendEvent(new vscode.OutputEvent(status.exception.message));
+                this.sendEvent(new vscode.OutputEvent(status.exception.message + '\n'));
                 
                 if (status.exception.code !== undefined) {
                     variables.push(new vscode.Variable('code', status.exception.code + ''));

--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -643,6 +643,10 @@ class PhpDebugSession extends vscode.DebugSession {
                     new vscode.Variable('type', status.exception.name),
                     new vscode.Variable('message', '"' + status.exception.message + '"')
                 ];
+                
+                // drop the messages into the full debug pane where it can be read in full.
+                this.sendEvent(new vscode.OutputEvent(status.exception.message));
+                
                 if (status.exception.code !== undefined) {
                     variables.push(new vscode.Variable('code', status.exception.code + ''));
                 }


### PR DESCRIPTION
so they can be fully read with line wrapping with ease.

![screen shot 2016-08-12 at 5 42 08 pm](https://cloud.githubusercontent.com/assets/881944/17638999/302deeca-60b4-11e6-8325-6f490463af5b.png)
