### PR TITLE
Make max_depth and max_children configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ In your project, go to the debugger and hit the little gear icon and choose _PHP
  - `localSourceRoot`: The path to the folder that is being served by your webserver and maps to `serverSourceRoot` (for example `"${workspaceRoot}/public"`)
  - `serverSourceRoot`: The path on the remote host where your webroot is located (for example `"/var/www"`)
  - `log`: Wether to log all communication between VS Code and the adapter to the debug console. See _Troubleshooting_ further down.
+ - `xdebugSettings`: Contains configuration to fine tuning Xdebug to your needs. Possible values are
+    - `maxDepth`: The max number of nested levels of array elements and object properties are displayed (default 5)
+    - `maxChildren`: The max number of array children and object properties shown when variables are displayed (default 100)
+
+    For example, if debugger is slow loading vars you can try to work on this property for example lower `maxDepth` or `maxChildren`. 
 
 Options specific to CLI debugging:
  - `program`: Path to the script that should be launched

--- a/README.md
+++ b/README.md
@@ -44,13 +44,12 @@ In your project, go to the debugger and hit the little gear icon and choose _PHP
  - `localSourceRoot`: The path to the folder that is being served by your webserver and maps to `serverSourceRoot` (for example `"${workspaceRoot}/public"`)
  - `serverSourceRoot`: The path on the remote host where your webroot is located (for example `"/var/www"`)
  - `log`: Wether to log all communication between VS Code and the adapter to the debug console. See _Troubleshooting_ further down.
- - `xdebugSettings`: Contains configuration to fine tuning Xdebug to your needs.
-    See feature names that can be set in [Xdebug documentation](https://xdebug.org/docs-dbgp.php#feature-names).
-    Remember that values **must** be string. The default Xdebug values are used if not defined.
-
-    For example, you can play with `max_children` and `max_depth` to change the max number of array or object children retrieved
-    and the max depth in structures as array and object. This give you the ability to speed up the debugger obviously showing
-    less data. 
+ - `xdebugSettings`: Allows you to override XDebug's remote debugging settings to fine tuning XDebug to your needs. For example, you can play with `max_children` and `max_depth` to change the max number of array and object children that are retrieved and the max depth in structures like arrays and objects. This can speed up the debugger on slow machines.
+   For a full list of feature names that can be set please refer to the [XDebug documentation](https://xdebug.org/docs-dbgp.php#feature-names).
+    - `max_children`: max number of array or object children to initially retrieve
+    - `max_data`: max amount of variable data to initially retrieve.
+    - `max_depth`: maximum depth that the debugger engine may return when sending arrays, hashs or object structures to the IDE.
+    - `show_hidden`: This feature can get set by the IDE if it wants to have more detailed internal information on properties (eg. private members of classes, etc.) Zero means that hidden members are not shown to the IDE.
 
 Options specific to CLI debugging:
  - `program`: Path to the script that should be launched

--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ In your project, go to the debugger and hit the little gear icon and choose _PHP
  - `localSourceRoot`: The path to the folder that is being served by your webserver and maps to `serverSourceRoot` (for example `"${workspaceRoot}/public"`)
  - `serverSourceRoot`: The path on the remote host where your webroot is located (for example `"/var/www"`)
  - `log`: Wether to log all communication between VS Code and the adapter to the debug console. See _Troubleshooting_ further down.
- - `xdebugSettings`: Contains configuration to fine tuning Xdebug to your needs. Possible values are
-    - `maxDepth`: The max number of nested levels of array elements and object properties are displayed (default 5)
-    - `maxChildren`: The max number of array children and object properties shown when variables are displayed (default 100)
+ - `xdebugSettings`: Contains configuration to fine tuning Xdebug to your needs.
+    See feature names that can be set in [Xdebug documentation](https://xdebug.org/docs-dbgp.php#feature-names).
+    Remember that values **must** be string. The default Xdebug values are used if not defined.
 
-    For example, if debugger is slow loading vars you can try to work on this property for example lower `maxDepth` or `maxChildren`. 
+    For example, you can play with `max_children` and `max_depth` to change the max number of array or object children retrieved
+    and the max depth in structures as array and object. This give you the ability to speed up the debugger obviously showing
+    less data. 
 
 Options specific to CLI debugging:
  - `program`: Path to the script that should be launched

--- a/package.json
+++ b/package.json
@@ -151,6 +151,14 @@
               "log": {
                 "type": "boolean",
                 "description": "If true, will log all communication between VS Code and the adapter"
+              },
+              "xdebugSettings": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Xdebug settings to fine tuning",
+                "default": {}
               }
             }
           }
@@ -160,7 +168,11 @@
             "name": "Listen for XDebug",
             "type": "php",
             "request": "launch",
-            "port": 9000
+            "port": 9000,
+            "xdebugSettings": {
+              "maxDepth": "5",
+              "maxChildren": "100"
+            }
           },
           {
             "name": "Launch currently open script",
@@ -168,7 +180,11 @@
             "request": "launch",
             "program": "${file}",
             "cwd": "${fileDirname}",
-            "port": 9000
+            "port": 9000,
+            "xdebugSettings": {
+              "maxDepth": "5",
+              "maxChildren": "100"
+            }
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
                   "show_hidden": {
                     "enum": [0, 1],
                     "description": "This feature can get set by the IDE if it wants to have more detailed internal information on properties (eg. private members of classes, etc.) Zero means that hidden members are not shown to the IDE"
+                  }
                 },
                 "description": "Overrides for XDebug remote debugging settings. See https://xdebug.org/docs-dbgp.php#feature-names",
                 "default": {}

--- a/package.json
+++ b/package.json
@@ -154,10 +154,20 @@
               },
               "xdebugSettings": {
                 "type": "object",
-                "additionalProperties": {
-                  "type": "string"
+                "properties": {
+                  "max_children": {
+                    "type": "integer",
+                    "description": "max number of array or object children to initially retrieve"
+                  },
+                  "max_data": {
+                    "type": "integer",
+                    "description": "max amount of variable data to initially retrieve"
+                  },
+                  "show_hidden": {
+                    "enum": [0, 1],
+                    "description": "This feature can get set by the IDE if it wants to have more detailed internal information on properties (eg. private members of classes, etc.) Zero means that hidden members are not shown to the IDE"
                 },
-                "description": "Xdebug settings to fine tuning",
+                "description": "Overrides for XDebug remote debugging settings. See https://xdebug.org/docs-dbgp.php#feature-names",
                 "default": {}
               }
             }
@@ -168,8 +178,7 @@
             "name": "Listen for XDebug",
             "type": "php",
             "request": "launch",
-            "port": 9000,
-            "xdebugSettings": {}
+            "port": 9000
           },
           {
             "name": "Launch currently open script",
@@ -177,8 +186,7 @@
             "request": "launch",
             "program": "${file}",
             "cwd": "${fileDirname}",
-            "port": 9000,
-            "xdebugSettings": {}
+            "port": 9000
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -169,10 +169,7 @@
             "type": "php",
             "request": "launch",
             "port": 9000,
-            "xdebugSettings": {
-              "maxDepth": "5",
-              "maxChildren": "100"
-            }
+            "xdebugSettings": {}
           },
           {
             "name": "Launch currently open script",
@@ -181,10 +178,7 @@
             "program": "${file}",
             "cwd": "${fileDirname}",
             "port": 9000,
-            "xdebugSettings": {
-              "maxDepth": "5",
-              "maxChildren": "100"
-            }
+            "xdebugSettings": {}
           }
         ]
       }

--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -10,7 +10,6 @@ import * as util from 'util';
 import * as fs from 'fs';
 import {Terminal} from './terminal';
 import {isSameUri, convertClientPathToDebugger, convertDebuggerPathToClient} from './paths';
-import * as semver from 'semver';
 
 if (process.env['VSCODE_NLS_CONFIG']) {
     try {

--- a/src/test/adapter.ts
+++ b/src/test/adapter.ts
@@ -382,7 +382,8 @@ describe('PHP Debug Adapter', () => {
                 client.launch({
                     program,
                     xdebugSettings: {
-                        max_children: '100'
+                        max_data: 10000,
+                        max_children: 100
                     }
                 }),
                 client.waitForEvent('initialized')

--- a/src/test/adapter.ts
+++ b/src/test/adapter.ts
@@ -379,7 +379,12 @@ describe('PHP Debug Adapter', () => {
 
         beforeEach(async () => {
             await Promise.all([
-                client.launch({program}),
+                client.launch({
+                    program,
+                    xdebugSettings: {
+                        max_children: '100'
+                    }
+                }),
                 client.waitForEvent('initialized')
             ]);
             await client.setBreakpointsRequest({source: {path: program}, breakpoints: [{line: 17}]});

--- a/src/xdebugConnection.ts
+++ b/src/xdebugConnection.ts
@@ -690,7 +690,7 @@ export class Connection extends DbgpConnection {
      *  - show_hidden
      *  - notify_ok
      */
-    public async sendFeatureSetCommand(feature: string, value: string): Promise<FeatureSetResponse> {
+    public async sendFeatureSetCommand(feature: string, value: string | number): Promise<FeatureSetResponse> {
         return new FeatureSetResponse(await this._enqueueCommand('feature_set', `-n ${feature} -v ${value}`), this);
     }
 


### PR DESCRIPTION
This PR add the ability to configure `max_depth` and `max_children` in launch.json file.

I left the previous values `max_depth` 5 and `max_children` 100 as default.
