### PR TITLE
fix(phpDebug): Make connection init more robust.

### DIFF
--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -290,12 +290,8 @@ class PhpDebugSession extends vscode.DebugSession {
                                 )
                             )
                         } catch (error) {
-                            this.sendEvent(
-                                new vscode.OutputEvent(
-                                    'Failed to set Xdebug settings: ' +
-                                        (error instanceof Error ? error.message : error) +
-                                        '\n'
-                                )
+                            throw new Error(
+                                'Error applying xdebugSettings: ' + (error instanceof Error ? error.message : error)
                             )
                         }
 
@@ -304,12 +300,15 @@ class PhpDebugSession extends vscode.DebugSession {
                         // request breakpoints from VS Code
                         await this.sendEvent(new vscode.InitializedEvent())
                     } catch (error) {
-                        this.sendEvent(new vscode.OutputEvent((error instanceof Error ? error.message : error) + '\n'))
+                        this.sendEvent(
+                            new vscode.OutputEvent((error instanceof Error ? error.message : error) + '\n', 'stderr')
+                        )
+                        this.shutdown()
                     }
                 })
                 server.on('error', (error: Error) => {
-                    this.sendEvent(new vscode.OutputEvent(error.message + '\n'))
-                    this.shutdown()
+                    this.sendEvent(new vscode.OutputEvent('ERROR: ' + error.message + '\n', 'stderr'))
+                    this.sendErrorResponse(response, <Error>error)
                 })
                 server.listen(args.port || 9000, (error: NodeJS.ErrnoException) => (error ? reject(error) : resolve()))
             })


### PR DESCRIPTION
Move 'started' event after Xdebug settings have been set to make sure that 'run' is not executed before settings are processed and make sure that invalid settings don't prevent init from completing. Add some line feeds to output messages.

The main issue I stumbled on regularly was that because the 'started' event was emitted before the xdebugSettings from launch.json had been processed, occasionally the run command would be sent to Xdebug before the feature_set commands. When the feature_set commands were eventually sent, Xdebug was already in 'stopping' state and returned an error. This error was not caught and resulted in the vscode.InitializedEvent() being missed. This, in turn lead to a situation where the requests were displayed as running in the call stack window but got stuck without completing. 