### PR TITLE
Fixed Inconsistencies between Drive Paths on Windows (C:\ vs c:\)

### DIFF
--- a/src/paths.ts
+++ b/src/paths.ts
@@ -94,7 +94,6 @@ export function convertClientPathToDebugger(localPath: string, pathMapping?: { [
     } else {
         serverFileUri = localFileUri
     }
-
     return serverFileUri
 }
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -53,11 +53,10 @@ export function convertClientPathToDebugger(localPath: string, pathMapping?: { [
     let localSourceRoot: string | undefined
     let serverSourceRoot: string | undefined
     let localFileUri = fileUrl(localPath, { resolve: false })
-    let localFileUriLower = fileUrl(localPath.replace(/[a-zA-Z]:\\/, (match: any) => match.toLowerCase()), {
+    let localFileUriLower = fileUrl(localPath.replace(/[A-Z]:\\/, match => match.toLowerCase()), {
         resolve: false,
     })
     let serverFileUri: string
-    let uriWasLowerCased = false
     if (pathMapping) {
         for (const mappedServerPath of Object.keys(pathMapping)) {
             const mappedLocalSource = pathMapping[mappedServerPath]
@@ -71,13 +70,11 @@ export function convertClientPathToDebugger(localPath: string, pathMapping?: { [
     }
     if (localSourceRoot) {
         localSourceRoot = localSourceRoot.replace(/^[A-Z]:\\/, match => {
-            uriWasLowerCased = true
             return match.toLowerCase()
         })
     }
     if (serverSourceRoot) {
         serverSourceRoot = serverSourceRoot.replace(/^[A-Z]:\\/, match => {
-            uriWasLowerCased = true
             return match.toLowerCase()
         })
     }
@@ -94,13 +91,6 @@ export function convertClientPathToDebugger(localPath: string, pathMapping?: { [
         const urlRelativeToSourceRoot = urlRelative(localSourceRootUrl, localFileUriLower)
         // resolve from the server source root
         serverFileUri = url.resolve(serverSourceRootUrl, urlRelativeToSourceRoot)
-
-        // we lowercased the Url, maybe we should undo that
-        if (uriWasLowerCased) {
-            serverFileUri = serverFileUri.replace(/\/\/\/[a-z]:/, match => {
-                return match.toUpperCase()
-            })
-        }
     } else {
         serverFileUri = localFileUri
     }

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -53,9 +53,11 @@ export function convertClientPathToDebugger(localPath: string, pathMapping?: { [
     let localSourceRoot: string | undefined
     let serverSourceRoot: string | undefined
     let localFileUri = fileUrl(localPath, { resolve: false })
-    let localFileUriLower = fileUrl(localPath.replace(/[a-zA-Z]:\\/, (match: any) => match.toLowerCase()), { resolve: false })
+    let localFileUriLower = fileUrl(localPath.replace(/[a-zA-Z]:\\/, (match: any) => match.toLowerCase()), {
+        resolve: false,
+    })
     let serverFileUri: string
-    let uriWasLowerCased = false;
+    let uriWasLowerCased = false
     if (pathMapping) {
         for (const mappedServerPath of Object.keys(pathMapping)) {
             const mappedLocalSource = pathMapping[mappedServerPath]
@@ -69,15 +71,15 @@ export function convertClientPathToDebugger(localPath: string, pathMapping?: { [
     }
     if (localSourceRoot) {
         localSourceRoot = localSourceRoot.replace(/^[A-Z]:\\/, match => {
-            uriWasLowerCased = true;
+            uriWasLowerCased = true
             return match.toLowerCase()
-        });
+        })
     }
     if (serverSourceRoot) {
         serverSourceRoot = serverSourceRoot.replace(/^[A-Z]:\\/, match => {
-            uriWasLowerCased = true;
-            return match.toLowerCase();
-        });
+            uriWasLowerCased = true
+            return match.toLowerCase()
+        })
     }
     if (serverSourceRoot && localSourceRoot) {
         let localSourceRootUrl = fileUrl(localSourceRoot, { resolve: false })
@@ -96,8 +98,8 @@ export function convertClientPathToDebugger(localPath: string, pathMapping?: { [
         // we lowercased the Url, maybe we should undo that
         if (uriWasLowerCased) {
             serverFileUri = serverFileUri.replace(/\/\/\/[a-z]:/, match => {
-                return match.toUpperCase();
-            });
+                return match.toUpperCase()
+            })
         }
     } else {
         serverFileUri = localFileUri

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -52,8 +52,7 @@ export function convertDebuggerPathToClient(
 export function convertClientPathToDebugger(localPath: string, pathMapping?: { [index: string]: string }): string {
     let localSourceRoot: string | undefined
     let serverSourceRoot: string | undefined
-    let localFileUri = fileUrl(localPath, { resolve: false })
-    let localFileUriLower = fileUrl(localPath.replace(/[A-Z]:\\/, match => match.toLowerCase()), {
+    let localFileUri = fileUrl(localPath.replace(/[A-Z]:\\/, match => match.toLowerCase()), {
         resolve: false,
     })
     let serverFileUri: string
@@ -88,7 +87,7 @@ export function convertClientPathToDebugger(localPath: string, pathMapping?: { [
             serverSourceRootUrl += '/'
         }
         // get the part of the path that is relative to the source root
-        const urlRelativeToSourceRoot = urlRelative(localSourceRootUrl, localFileUriLower)
+        const urlRelativeToSourceRoot = urlRelative(localSourceRootUrl, localFileUri)
         // resolve from the server source root
         serverFileUri = url.resolve(serverSourceRootUrl, urlRelativeToSourceRoot)
     } else {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -52,9 +52,8 @@ export function convertDebuggerPathToClient(
 export function convertClientPathToDebugger(localPath: string, pathMapping?: { [index: string]: string }): string {
     let localSourceRoot: string | undefined
     let serverSourceRoot: string | undefined
-    let localFileUri = fileUrl(localPath.replace(/[A-Z]:\\/, match => match.toLowerCase()), {
-        resolve: false,
-    })
+    // XDebug always lowercases Windows drive letters in file URIs
+    let localFileUri = fileUrl(localPath.replace(/^[A-Z]:\\/, match => match.toLowerCase()), { resolve: false })
     let serverFileUri: string
     if (pathMapping) {
         for (const mappedServerPath of Object.keys(pathMapping)) {
@@ -68,14 +67,10 @@ export function convertClientPathToDebugger(localPath: string, pathMapping?: { [
         }
     }
     if (localSourceRoot) {
-        localSourceRoot = localSourceRoot.replace(/^[A-Z]:\\/, match => {
-            return match.toLowerCase()
-        })
+        localSourceRoot = localSourceRoot.replace(/^[A-Z]:\\/, match => match.toLowerCase())
     }
     if (serverSourceRoot) {
-        serverSourceRoot = serverSourceRoot.replace(/^[A-Z]:\\/, match => {
-            return match.toLowerCase()
-        })
+        serverSourceRoot = serverSourceRoot.replace(/^[A-Z]:\\/, match => match.toLowerCase())
     }
     if (serverSourceRoot && localSourceRoot) {
         let localSourceRootUrl = fileUrl(localSourceRoot, { resolve: false })

--- a/src/test/paths.ts
+++ b/src/test/paths.ts
@@ -94,6 +94,16 @@ describe('paths', () => {
                     'file:///app/source.php'
                 )
             })
+            ;(process.platform === 'win32' ? it : it.skip)('should convert a windows path with inconsistent casing to a unix URI', () => {
+                const localSourceRoot = 'C:\\Users\\felix\\myproject';
+                const serverSourceRoot = '/var/www';
+                assert.equal(
+                    convertClientPathToDebugger('c:\\Users\\felix\\myproject\\test.php', {
+                        [serverSourceRoot]: localSourceRoot,
+                    }),
+                    'file:///var/www/test.php'
+                );
+            })
             // windows to windows
             ;(process.platform === 'win32' ? it : it.skip)('should convert a windows path to a windows URI', () => {
                 // site

--- a/src/test/paths.ts
+++ b/src/test/paths.ts
@@ -64,7 +64,7 @@ describe('paths', () => {
                         'C:\\Program Files\\Apache\\2.4\\htdocs': '/home/felix/mysite',
                         'C:\\Program Files\\MySource': '/home/felix/mysource',
                     }),
-                    'file:///C:/Program%20Files/Apache/2.4/htdocs/site.php'
+                    'file:///c:/Program%20Files/Apache/2.4/htdocs/site.php'
                 )
                 // source
                 assert.equal(
@@ -72,7 +72,7 @@ describe('paths', () => {
                         'C:\\Program Files\\Apache\\2.4\\htdocs': '/home/felix/mysite',
                         'C:\\Program Files\\MySource': '/home/felix/mysource',
                     }),
-                    'file:///C:/Program%20Files/MySource/source.php'
+                    'file:///c:/Program%20Files/MySource/source.php'
                 )
             })
             // windows to unix
@@ -115,7 +115,7 @@ describe('paths', () => {
                         'C:\\Program Files\\Apache\\2.4\\htdocs': 'C:\\Users\\felix\\mysite',
                         'C:\\Program Files\\MySource': 'C:\\Users\\felix\\mysource',
                     }),
-                    'file:///C:/Program%20Files/Apache/2.4/htdocs/site.php'
+                    'file:///c:/Program%20Files/Apache/2.4/htdocs/site.php'
                 )
                 // source
                 assert.equal(
@@ -123,7 +123,7 @@ describe('paths', () => {
                         'C:\\Program Files\\Apache\\2.4\\htdocs': 'C:\\Users\\felix\\mysite',
                         'C:\\Program Files\\MySource': 'C:\\Users\\felix\\mysource',
                     }),
-                    'file:///C:/Program%20Files/MySource/source.php'
+                    'file:///c:/Program%20Files/MySource/source.php'
                 )
             })
         })

--- a/src/test/paths.ts
+++ b/src/test/paths.ts
@@ -94,16 +94,19 @@ describe('paths', () => {
                     'file:///app/source.php'
                 )
             })
-            ;(process.platform === 'win32' ? it : it.skip)('should convert a windows path with inconsistent casing to a unix URI', () => {
-                const localSourceRoot = 'C:\\Users\\felix\\myproject';
-                const serverSourceRoot = '/var/www';
-                assert.equal(
-                    convertClientPathToDebugger('c:\\Users\\felix\\myproject\\test.php', {
-                        [serverSourceRoot]: localSourceRoot,
-                    }),
-                    'file:///var/www/test.php'
-                );
-            })
+            ;(process.platform === 'win32' ? it : it.skip)(
+                'should convert a windows path with inconsistent casing to a unix URI',
+                () => {
+                    const localSourceRoot = 'C:\\Users\\felix\\myproject'
+                    const serverSourceRoot = '/var/www'
+                    assert.equal(
+                        convertClientPathToDebugger('c:\\Users\\felix\\myproject\\test.php', {
+                            [serverSourceRoot]: localSourceRoot,
+                        }),
+                        'file:///var/www/test.php'
+                    )
+                }
+            )
             // windows to windows
             ;(process.platform === 'win32' ? it : it.skip)('should convert a windows path to a windows URI', () => {
                 // site

--- a/src/test/paths.ts
+++ b/src/test/paths.ts
@@ -29,7 +29,7 @@ describe('paths', () => {
             it('should convert a windows path to a URI', () => {
                 assert.equal(
                     convertClientPathToDebugger('C:\\Users\\felix\\test.php'),
-                    'file:///C:/Users/felix/test.php'
+                    'file:///c:/Users/felix/test.php'
                 )
             })
             it('should convert a unix path to a URI', () => {


### PR DESCRIPTION
It seems like VS Code or another dependency has begun using lowercase drive names in some places, but not in `${workspaceRoot}`

This will make it match up.