### PR TITLE
Improve README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,10 @@ Install the extension: Press `F1`, type `ext install php-debug`.
 This extension is a debug adapter between VS Code and [XDebug](https://xdebug.org/) by Derick Rethan. XDebug is a PHP extension (a `.so` file on Linux and a `.dll` on Windows) that needs to be installed on your server.
 
  1. [Install XDebug](https://xdebug.org/docs/install)
-  ***I highly recommend you make a simple `test.php` file, put a `phpinfo();` statement in there, then copy the output and paste it into the [XDebug installation wizard](https://xdebug.org/wizard.php). It will analyze it and give you tailored installation instructions for your environment.***
-  In short:
-   - On Windows: [Download](https://xdebug.org/download.php) the appropiate precompiled DLL for your PHP version, architecture (64/32 Bit), thread safety (TS/NTS) and Visual Studio compiler version and place it in your PHP extension folder.
-   - On Linux: Either download the source code as a tarball or [clone it with git](https://xdebug.org/docs/install#source), then [compile it](https://xdebug.org/docs/install#compile).
- 2. [Configure PHP to use XDebug](https://xdebug.org/docs/install#configure-php) by adding `zend_extension=path/to/xdebug` to your php.ini.
-  The path of your php.ini is shown in your `phpinfo()` output under "Loaded Configuration File".
+  ***I highly recommend you make a simple `test.php` file, put a `phpinfo();` statement in there, then copy the output and paste it into the [XDebug installation wizard](https://xdebug.org/wizard.php). It will analyze it and give you tailored installation instructions for your environment.*** In short:
+    - On Windows: [Download](https://xdebug.org/download.php) the appropiate precompiled DLL for your PHP version, architecture (64/32 Bit), thread safety (TS/NTS) and Visual Studio compiler version and place it in your PHP extension folder.
+    - On Linux: Either download the source code as a tarball or [clone it with git](https://xdebug.org/docs/install#source), then [compile it](https://xdebug.org/docs/install#compile).
+ 2. [Configure PHP to use XDebug](https://xdebug.org/docs/install#configure-php) by adding `zend_extension=path/to/xdebug` to your php.ini. The path of your php.ini is shown in your `phpinfo()` output under "Loaded Configuration File".
  3. Enable remote debugging in your php.ini:
 
   ```ini
@@ -28,6 +26,7 @@ This extension is a debug adapter between VS Code and [XDebug](https://xdebug.or
   xdebug.remote_autostart = 1
   ```
   There are other ways to tell XDebug to connect to a remote debugger than `remote_autostart`, like cookies, query parameters or browser extensions. I recommend `remote_autostart` because it "just works". There are also a variety of other options, like the port (by default 9000), please see the [XDebug documentation on remote debugging](https://xdebug.org/docs/remote#starting) for more information.
+
  4. If you are doing web development, don't forget to restart your webserver to reload the settings
  5. Verify your installation by checking your `phpinfo()` output for an XDebug section.
 


### PR DESCRIPTION
- Installation step 1 subitems weren't indented
- Installation steps 4 and 5 were stuck to the previous paragraph