### PR TITLE
Prevent deadlock by only updating breakpoints on needed connections

### DIFF
--- a/src/xdebugConnection.ts
+++ b/src/xdebugConnection.ts
@@ -649,8 +649,8 @@ export class Connection extends DbgpConnection {
         }
         commandString += '\0'
         const data = iconv.encode(commandString, ENCODING)
-        await this.write(data)
         this._pendingCommands.set(transactionId, command)
+        await this.write(data)
     }
 
     public close() {
@@ -752,21 +752,25 @@ export class Connection extends DbgpConnection {
 
     /** sends a run command */
     public async sendRunCommand(): Promise<StatusResponse> {
+        this.emit('continue-event');
         return new StatusResponse(await this._enqueueCommand('run'), this)
     }
 
     /** sends a step_into command */
     public async sendStepIntoCommand(): Promise<StatusResponse> {
+        this.emit('continue-event');
         return new StatusResponse(await this._enqueueCommand('step_into'), this)
     }
 
     /** sends a step_over command */
     public async sendStepOverCommand(): Promise<StatusResponse> {
+        this.emit('continue-event');
         return new StatusResponse(await this._enqueueCommand('step_over'), this)
     }
 
     /** sends a step_out command */
     public async sendStepOutCommand(): Promise<StatusResponse> {
+        this.emit('continue-event');
         return new StatusResponse(await this._enqueueCommand('step_out'), this)
     }
 


### PR DESCRIPTION
This fixes #164 

In this PR:
* When making calls related to updating the breakpoints, if there is a connection set in `_waitingConnections`, it only uses that connection instead of all.  When that is the case the breakpoints are likely only getting updated as part of initializing the new connection.  This fixes the main problem mentioned in #164 that was caused because it was sending the breakpoint calls to the first connection, when that connection was locked up waiting on response from second connection.  Doing it this way eliminates the deadlock, at least in this scenario.
* When sending a command, record the command in `_pendingConnections` **before** it makes the call, not after.  This ensures it correctly only attempts to send one command at a time and waits for the response before sending another.
* When sending a command that tells xdebug to continue executing PHP (like run, step_into, etc), it now sends the `ContinuedEvent`.  With the change, now once you hit continue or step into etc. it immediately behaves like the execution has continued.  Before the change if there was something like a sleep() command, when you hit continue, it would "seem" like nothing happened as it appears to still be paused on a breakpoint when that is not the case.