### PR TITLE
Avoid deadlock with multiple connections when executing code and new connection opens

### DIFF
--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -593,17 +593,11 @@ class PhpDebugSession extends vscode.DebugSession {
                                                         functionBreakpoint.condition
                                                     )
                                                 )
-                                                // only capture each breakpoint once
-                                                if (connectionIndex === 0) {
-                                                    vscodeBreakpoints[index] = { verified: true }
-                                                }
+                                                vscodeBreakpoints[index] = { verified: true }
                                             } catch (error) {
-                                                // only capture each breakpoint once
-                                                if (connectionIndex === 0) {
-                                                    vscodeBreakpoints[index] = {
-                                                        verified: false,
-                                                        message: error instanceof Error ? error.message : error,
-                                                    }
+                                                vscodeBreakpoints[index] = {
+                                                    verified: false,
+                                                    message: error instanceof Error ? error.message : error,
                                                 }
                                             }
                                         })

--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -475,9 +475,12 @@ class PhpDebugSession extends vscode.DebugSession {
                     connections.map(async (connection, connectionIndex) => {
                         // Note: this does not use await for sendBreakpointListCommand() on purpose, to avoid causing a deadlock if connection is
                         // currently in process of executing PHP code
-                        const removeThenSet = () => {
+                        const breakpointSetup = () => {
                             return connection.sendBreakpointListCommand().then(async ({ breakpoints }) => {
+                                // clear breakpoints for this file
+                                // in the future when VS Code returns the breakpoint IDs it would be better to calculate the diff
                                 await Promise.all(this._removeBreakpoints(breakpoints, breakpointFilter))
+                                // set new breakpoints
                                 return Promise.all(
                                     xdebugBreakpoints.map((breakpoint, index) => {
                                         return connection
@@ -499,9 +502,9 @@ class PhpDebugSession extends vscode.DebugSession {
                         if (connection.isPendingExecuteCommand()) {
                             // There is a pending execute command which could lock the connection up, so do not
                             // wait on the response before continuing or it can get into a deadlock
-                            removeThenSet()
+                            breakpointSetup()
                         } else {
-                            await removeThenSet()
+                            await breakpointSetup()
                         }
                     })
                 )
@@ -526,7 +529,7 @@ class PhpDebugSession extends vscode.DebugSession {
                 connections.map(async connection => {
                     // Note: this does not use await for sendBreakpointListCommand() on purpose, to avoid causing a deadlock if connection is
                     // currently in process of executing PHP code
-                    const removeThenSet = () => {
+                    const breakpointSetup = () => {
                         return connection.sendBreakpointListCommand().then(async ({ breakpoints }) => {
                             await Promise.all(this._removeBreakpoints(breakpoints, breakpointFilter))
                             return Promise.all(
@@ -539,9 +542,9 @@ class PhpDebugSession extends vscode.DebugSession {
                     if (connection.isPendingExecuteCommand()) {
                         // There is a pending execute command which could lock the connection up, so do not
                         // wait on the response before continuing or it can get into a deadlock
-                        removeThenSet()
+                        breakpointSetup()
                     } else {
-                        await removeThenSet()
+                        await breakpointSetup()
                     }
                 })
             )
@@ -571,7 +574,7 @@ class PhpDebugSession extends vscode.DebugSession {
                     connections.map(async (connection, connectionIndex) => {
                         // Note: this does not use await for sendBreakpointListCommand() on purpose, to avoid causing a deadlock if connection is
                         // currently in process of executing PHP code
-                        const removeThenSet = () => {
+                        const breakpointSetup = () => {
                             return connection.sendBreakpointListCommand().then(async ({ breakpoints }) => {
                                 await Promise.all(this._removeBreakpoints(breakpoints, breakpointFilter))
                                 return Promise.all(
@@ -597,9 +600,9 @@ class PhpDebugSession extends vscode.DebugSession {
                         if (connection.isPendingExecuteCommand()) {
                             // There is a pending execute command which could lock the connection up, so do not
                             // wait on the response before continuing or it can get into a deadlock
-                            removeThenSet()
+                            breakpointSetup()
                         } else {
-                            await removeThenSet()
+                            await breakpointSetup()
                         }
                     })
                 )

--- a/src/xdebugConnection.ts
+++ b/src/xdebugConnection.ts
@@ -587,6 +587,7 @@ export class Connection extends DbgpConnection {
      */
     private _commandQueue: Command[] = []
 
+    /** Whether the connection is waiting for a response from an "execute command" (that results in executed PHP) */
     private _pendingExecuteCommand = false
 
     /** Constructs a new connection that uses the given socket to communicate with XDebug. */

--- a/src/xdebugConnection.ts
+++ b/src/xdebugConnection.ts
@@ -607,8 +607,8 @@ export class Connection extends DbgpConnection {
                 if (this._pendingCommands.has(transactionId)) {
                     const command = this._pendingCommands.get(transactionId)!
                     this._pendingCommands.delete(transactionId)
-                    command.resolveFn(response)
                     this._pendingExecuteCommand = false;
+                    command.resolveFn(response)
                 }
                 if (this._commandQueue.length > 0) {
                     const command = this._commandQueue.shift()!

--- a/src/xdebugConnection.ts
+++ b/src/xdebugConnection.ts
@@ -546,7 +546,7 @@ interface Command {
     /** callback that gets called if an error happened while parsing the response */
     rejectFn: (error?: Error) => any
     /** whether command results in PHP code being executed or not */
-    isExecuteCommand?: boolean
+    isExecuteCommand: boolean
 }
 
 /**
@@ -679,7 +679,7 @@ export class Connection extends DbgpConnection {
         commandString += '\0'
         const data = iconv.encode(commandString, ENCODING)
         this._pendingCommands.set(transactionId, command)
-        this._pendingExecuteCommand = !!command.isExecuteCommand
+        this._pendingExecuteCommand = command.isExecuteCommand
         if (this._pendingExecuteCommand) {
             // Since PHP execution commands block anything on the connection until it is
             // done executing, emit that the connection is about to go into such a locked state

--- a/src/xdebugConnection.ts
+++ b/src/xdebugConnection.ts
@@ -587,8 +587,14 @@ export class Connection extends DbgpConnection {
      */
     private _commandQueue: Command[] = []
 
-    /** Whether the connection is waiting for a response from an "execute command" (that results in executed PHP) */
     private _pendingExecuteCommand = false
+    /**
+     * Whether a command was started that executes PHP, which means the connection will be blocked from
+     * running any additional commands until the execution gets to the next stopping point or exits.
+     */
+    public get isPendingExecuteCommand(): boolean {
+        return this._pendingExecuteCommand
+    }
 
     /** Constructs a new connection that uses the given socket to communicate with XDebug. */
     constructor(socket: net.Socket) {
@@ -621,14 +627,6 @@ export class Connection extends DbgpConnection {
     /** Returns a promise that gets resolved once the init packet arrives */
     public waitForInitPacket(): Promise<InitPacket> {
         return this._initPromise
-    }
-
-    /**
-     * Whether a command was started that executes PHP, which means the connection will be blocked from
-     * running any additional commands until the execution gets to the next stopping point or exits.
-     */
-    public isPendingExecuteCommand(): boolean {
-        return this._pendingExecuteCommand
     }
 
     /**

--- a/src/xdebugConnection.ts
+++ b/src/xdebugConnection.ts
@@ -545,6 +545,8 @@ interface Command {
     resolveFn: (response: XMLDocument) => any
     /** callback that gets called if an error happened while parsing the response */
     rejectFn: (error?: Error) => any
+    /** whether command results in PHP code being executed or not */
+    isExecuteCommand?: boolean
 }
 
 /**
@@ -585,6 +587,8 @@ export class Connection extends DbgpConnection {
      */
     private _commandQueue: Command[] = []
 
+    private _pendingExecuteCommand = false
+
     /** Constructs a new connection that uses the given socket to communicate with XDebug. */
     constructor(socket: net.Socket) {
         super(socket)
@@ -603,6 +607,7 @@ export class Connection extends DbgpConnection {
                     const command = this._pendingCommands.get(transactionId)!
                     this._pendingCommands.delete(transactionId)
                     command.resolveFn(response)
+                    this._pendingExecuteCommand = false;
                 }
                 if (this._commandQueue.length > 0) {
                     const command = this._commandQueue.shift()!
@@ -617,6 +622,14 @@ export class Connection extends DbgpConnection {
         return this._initPromise
     }
 
+    /** 
+     * Whether a command was started that executes PHP, which means the connection will be blocked from
+     * running any additional commands until the execution gets to the next stopping point or exits.
+     */
+    public isPendingExecuteCommand(): boolean {
+        return this._pendingExecuteCommand;
+    }
+
     /**
      * Pushes a new command to the queue that will be executed after all the previous commands have finished and we received a response.
      * If the queue is empty AND there are no pending transactions (meaning we already received a response and XDebug is waiting for
@@ -624,13 +637,29 @@ export class Connection extends DbgpConnection {
      */
     private _enqueueCommand(name: string, args?: string, data?: string): Promise<XMLDocument> {
         return new Promise((resolveFn, rejectFn) => {
-            const command = { name, args, data, resolveFn, rejectFn }
-            if (this._commandQueue.length === 0 && this._pendingCommands.size === 0) {
-                this._executeCommand(command)
-            } else {
-                this._commandQueue.push(command)
-            }
+            this._enqueue({ name, args, data, resolveFn, rejectFn, isExecuteCommand: false })
         })
+    }
+
+    /**
+     * Pushes a new execute command (one that results in executing PHP code) to the queue that will be executed after all the previous 
+     * commands have finished and we received a response.
+     * If the queue is empty AND there are no pending transactions (meaning we already received a response and XDebug is waiting for
+     * commands) the command will be executed immediately.
+     */
+    private _enqueueExecuteCommand(name: string, args?: string, data?: string): Promise<XMLDocument> {
+        return new Promise((resolveFn, rejectFn) => {
+            this._enqueue({ name, args, data, resolveFn, rejectFn, isExecuteCommand: true })
+        })
+    }
+
+    /** Adds the given command to the queue, or executes immediately if no commands are currently being processed. */
+    private _enqueue(command: Command): void {
+        if (this._commandQueue.length === 0 && this._pendingCommands.size === 0) {
+            this._executeCommand(command)
+        } else {
+            this._commandQueue.push(command)
+        }
     }
 
     /**
@@ -649,8 +678,14 @@ export class Connection extends DbgpConnection {
         }
         commandString += '\0'
         const data = iconv.encode(commandString, ENCODING)
-        await this.write(data)
         this._pendingCommands.set(transactionId, command)
+        this._pendingExecuteCommand = !!command.isExecuteCommand
+        if (this._pendingExecuteCommand) {
+            // Since PHP execution commands block anything on the connection until it is
+            // done executing, emit that the connection is about to go into such a locked state
+            this.emit('before-execute-command')
+        }
+        await this.write(data)
     }
 
     public close() {
@@ -752,22 +787,22 @@ export class Connection extends DbgpConnection {
 
     /** sends a run command */
     public async sendRunCommand(): Promise<StatusResponse> {
-        return new StatusResponse(await this._enqueueCommand('run'), this)
+        return new StatusResponse(await this._enqueueExecuteCommand('run'), this)
     }
 
     /** sends a step_into command */
     public async sendStepIntoCommand(): Promise<StatusResponse> {
-        return new StatusResponse(await this._enqueueCommand('step_into'), this)
+        return new StatusResponse(await this._enqueueExecuteCommand('step_into'), this)
     }
 
     /** sends a step_over command */
     public async sendStepOverCommand(): Promise<StatusResponse> {
-        return new StatusResponse(await this._enqueueCommand('step_over'), this)
+        return new StatusResponse(await this._enqueueExecuteCommand('step_over'), this)
     }
 
     /** sends a step_out command */
     public async sendStepOutCommand(): Promise<StatusResponse> {
-        return new StatusResponse(await this._enqueueCommand('step_out'), this)
+        return new StatusResponse(await this._enqueueExecuteCommand('step_out'), this)
     }
 
     /** sends a stop command */

--- a/src/xdebugConnection.ts
+++ b/src/xdebugConnection.ts
@@ -607,7 +607,7 @@ export class Connection extends DbgpConnection {
                 if (this._pendingCommands.has(transactionId)) {
                     const command = this._pendingCommands.get(transactionId)!
                     this._pendingCommands.delete(transactionId)
-                    this._pendingExecuteCommand = false;
+                    this._pendingExecuteCommand = false
                     command.resolveFn(response)
                 }
                 if (this._commandQueue.length > 0) {
@@ -623,12 +623,12 @@ export class Connection extends DbgpConnection {
         return this._initPromise
     }
 
-    /** 
+    /**
      * Whether a command was started that executes PHP, which means the connection will be blocked from
      * running any additional commands until the execution gets to the next stopping point or exits.
      */
     public isPendingExecuteCommand(): boolean {
-        return this._pendingExecuteCommand;
+        return this._pendingExecuteCommand
     }
 
     /**
@@ -643,7 +643,7 @@ export class Connection extends DbgpConnection {
     }
 
     /**
-     * Pushes a new execute command (one that results in executing PHP code) to the queue that will be executed after all the previous 
+     * Pushes a new execute command (one that results in executing PHP code) to the queue that will be executed after all the previous
      * commands have finished and we received a response.
      * If the queue is empty AND there are no pending transactions (meaning we already received a response and XDebug is waiting for
      * commands) the command will be executed immediately.


### PR DESCRIPTION
Fixes #164 

Original PR: #292 

This PR reworks how the original one does things after feedback and as noted below.  It made it a lot cleaner to start fresh on a new branch which is why I didn't add the changes on to the original PR...

This introduces a new concept in the xDebug connection:  "execution commands": these are commands that result in PHP being executed.  The way xDebug works, if one of these commands is run, that connection is hung until the PHP code is done executing (until it gets to the next stopping point).  By keeping track of when such commands are still in progress, and making it something that the adapter can check, it allows the adapter to specifically code for when the connection is currently hung.  Which allows preventing the deadlock situation described in #164 

The adapter also now emits `before-execution-command` since it results in possibly going into a hung state for a while.  The adapter uses that event to send a `ContinueEvent`, this is just a side advantage that makes the interface more responsive.  Before when you click continue, if the PHP code is hung for whatever reason (it is slow, it has a lot to do, etc), it appears that it did not work as it appears to still be stopped on a breakpoint (but it is not, which you can tell by trying to view any of the details in the debug pane).  With the change, now when you click continue it immediately changes the process back to "running" state which is more truthful.

**EDIT:** Since #164 has a lot of comments, here is the **tl;dr:** deadlock explanation: 
1. Connection 1 makes a second connection with curl.
2. It sends command to all connections to set breakpoints, and waits for response.
3. The second connection hangs as it is waiting for connection 1 to set breakpoints, connection 1 hangs without setting those breakpoints because it is waiting for connection 2 to respond and can't do anything until that completes.

This PR makes it not wait for the breakpoints to be set on a connection if the connection is waiting for code to execute.  So now connection 2 can finish initializing and run, no more deadlock.