### PR TITLE
fix(phpDebug): Set evaluateName for variables to allow copy

### DIFF
--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -835,6 +835,7 @@ class PhpDebugSession extends vscode.DebugSession {
                 variables = properties.map(property => {
                     const displayValue = formatPropertyValue(property)
                     let variablesReference: number
+                    let evaluateName: string
                     if (property.hasChildren || property.type === 'array' || property.type === 'object') {
                         // if the property has children, we have to send a variableReference back to VS Code
                         // so it can receive the child elements in another request.
@@ -848,11 +849,17 @@ class PhpDebugSession extends vscode.DebugSession {
                     } else {
                         variablesReference = 0
                     }
+                    if (property instanceof xdebug.Property) {
+                        evaluateName = property.fullName
+                    } else {
+                        evaluateName = property.name
+                    }
                     const variable: VSCodeDebugProtocol.Variable = {
                         name: property.name,
                         value: displayValue,
                         type: property.type,
                         variablesReference,
+                        evaluateName
                     }
                     return variable
                 })

--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -859,7 +859,7 @@ class PhpDebugSession extends vscode.DebugSession {
                         value: displayValue,
                         type: property.type,
                         variablesReference,
-                        evaluateName
+                        evaluateName,
                     }
                     return variable
                 })


### PR DESCRIPTION
Fixes #278 

This sets `evaluateName` on the variable object passed back to vscode.  I guess this is something from a newer version of vscode because I remember the copy used to work.

It sets it to `fullName` for the property if available (which will be something like `$var->property` if it is for a child), or `name` otherwise, which will be for top level variables.