### PR TITLE
Allow for port to be tcp or a unix socket path

### DIFF
--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -52,8 +52,8 @@ function formatPropertyValue(property: xdebug.BaseProperty): string {
 interface LaunchRequestArguments extends VSCodeDebugProtocol.LaunchRequestArguments {
     /** The address to bind to for listening for XDebug connections (default: all IPv6 connections if available, else all IPv4 connections) */
     hostname?: string
-    /** The port where the adapter should listen for XDebug connections (default: 9000) */
-    port?: number
+    /** The port where the adapter should listen for XDebug connections (default: 9000), can be tcp port or unix socket path */
+    port?: number | string
     /** Automatically stop target after launch. If not specified, target does not stop. */
     stopOnEntry?: boolean
     /** The source root on the server when doing remote debugging on a different host */


### PR DESCRIPTION
I have been using unix socket paths with vscode-php-debug in a multi-user remote vscode server enivonment. This allows for a clean non-conflicting usage of multiple php debugs with multiple docker containers on same host without having to share tcp ports. 
This is just a typing update so vscode doesn't complain when I use unix path for port.